### PR TITLE
Fix npm status badge version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# MotokoJS &middot; [![npm version](https://img.shields.io/npm/v/npm.svg?logo=npm)](https://www.npmjs.com/package/motoko) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/dfinity/motoko/issues)
+# MotokoJS &middot; [![npm version](https://img.shields.io/npm/v/motoko.svg?logo=npm)](https://www.npmjs.com/package/motoko) [![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/dfinity/motoko/issues)
 
 > ### Compile [Motoko](https://smartcontracts.org/) smart contracts in Node.js and the browser.
 


### PR DESCRIPTION
The npm badge in the readme now shows the version number for `motoko` rather than `npm` itself.