### PR TITLE
Add 'parent' property to AST nodes

### DIFF
--- a/examples/wasm.js
+++ b/examples/wasm.js
@@ -34,25 +34,25 @@ module Interface {
 print(">>> value = " # debug_show Interface.value);
 `);
 
-const wasiResult = wasiFile.wasm('wasi');
-console.log('WASI:', wasiResult);
+// const wasiResult = wasiFile.wasm('wasi');
+// console.log('WASI:', wasiResult);
 
-(async () => {
-    const { init, WASI } = require('@wasmer/wasi');
+// (async () => {
+//     const { init, WASI } = require('@wasmer/wasi');
 
-    await init();
+//     await init();
 
-    const wasi = new WASI({});
+//     const wasi = new WASI({});
 
-    const module = await (WebAssembly.compileStreaming || WebAssembly.compile)(
-        wasiResult.wasm,
-    );
-    await wasi.instantiate(module, {});
-    let exitCode = wasi.start();
-    let stdout = wasi.getStdoutString();
-    let stderr = wasi.getStderrString();
+//     const module = await (WebAssembly.compileStreaming || WebAssembly.compile)(
+//         wasiResult.wasm,
+//     );
+//     await wasi.instantiate(module, {});
+//     let exitCode = wasi.start();
+//     let stdout = wasi.getStdoutString();
+//     let stderr = wasi.getStderrString();
 
-    console.log(stdout);
-    console.error(stderr);
-    console.log('Exit code:', exitCode);
-})();
+//     console.log(stdout);
+//     console.error(stderr);
+//     console.log('Exit code:', exitCode);
+// })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.1.3",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.1.3",
+            "version": "3.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.1.3",
+    "version": "3.2.0",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,6 +16,7 @@ export interface Source {
 }
 
 export interface Node extends Partial<Source> {
+    parent?: Node | undefined;
     name: string;
     type?: string;
     doc?: string;
@@ -23,13 +24,18 @@ export interface Node extends Partial<Source> {
     args?: AST[];
 }
 
-export function simplifyAST(ast: CompilerNode): Node;
-export function simplifyAST(ast: CompilerAST[]): AST[];
-export function simplifyAST<T extends CompilerAST>(ast: T): T;
-
-export function simplifyAST(ast: CompilerAST): AST {
+export function simplifyAST(ast: CompilerNode, parent?: Node | undefined): Node;
+export function simplifyAST(
+    ast: CompilerAST[],
+    parent?: Node | undefined,
+): AST[];
+export function simplifyAST<T extends CompilerAST>(
+    ast: T,
+    parent?: Node | undefined,
+): T;
+export function simplifyAST(ast: CompilerAST, parent?: Node | undefined): AST {
     if (Array.isArray(ast)) {
-        return ast.map((a) => simplifyAST(a));
+        return ast.map((a) => simplifyAST(a, parent));
     }
     if (typeof ast !== 'object') {
         return ast;
@@ -43,7 +49,7 @@ export function simplifyAST(ast: CompilerAST): AST {
         const node: Node = {
             ...(typeof subAst === 'string'
                 ? { name: subAst }
-                : simplifyAST(subAst as any as CompilerNode)),
+                : simplifyAST(subAst as any as CompilerNode, parent)),
             start: [+start.args[1], +start.args[2]],
             end: [+end.args[1], +end.args[2]],
         };
@@ -58,7 +64,7 @@ export function simplifyAST(ast: CompilerAST): AST {
         return {
             ...(typeof typeAst === 'string'
                 ? { name: typeAst }
-                : simplifyAST(typeAst)),
+                : simplifyAST(typeAst, parent)),
             type,
         };
     }
@@ -67,12 +73,17 @@ export function simplifyAST(ast: CompilerAST): AST {
         return {
             ...(typeof docAst === 'string'
                 ? { name: docAst }
-                : simplifyAST(docAst)),
+                : simplifyAST(docAst, parent)),
             doc,
         };
     }
-    return {
+    const node: Node = {
         name: ast.name,
-        args: simplifyAST(ast.args),
     };
+    Object.defineProperty(node, 'parent', {
+        value: parent,
+        enumerable: false,
+    });
+    node.args = simplifyAST(ast.args, node);
+    return node;
 }


### PR DESCRIPTION
Adds a `parent` property which can be used to traverse up a Motoko abstract syntax tree. Note that this property is non-enumerable so that it's still possible to print and serialize AST nodes without encountering circular references. 