### PR TITLE
Fix AST parent propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -46,13 +46,12 @@ export function simplifyAST(ast: CompilerAST, parent?: Node | undefined): AST {
             CompilerSpan,
             CompilerAST,
         ];
-        const node: Node = {
-            ...(typeof subAst === 'string'
+        const node: Node =
+            typeof subAst === 'string'
                 ? { name: subAst }
-                : simplifyAST(subAst as any as CompilerNode, parent)),
-            start: [+start.args[1], +start.args[2]],
-            end: [+end.args[1], +end.args[2]],
-        };
+                : simplifyAST(subAst as any as CompilerNode, parent);
+        node.start = [+start.args[1], +start.args[2]];
+        node.end = [+end.args[1], +end.args[2]];
         const file = start.args[0];
         if (file) {
             node.file = file;

--- a/tests/ast.test.ts
+++ b/tests/ast.test.ts
@@ -1,0 +1,15 @@
+import mo from '../src/versions/moc';
+import { Node } from '../src/ast';
+
+describe('ast', () => {
+    test('parent property', async () => {
+        const ast = mo.parseMotoko('let x = 0; x');
+        const args = ast.args!.filter(
+            (arg) => arg && typeof arg === 'object' && !Array.isArray(arg),
+        ) as Node[];
+        expect(args).toHaveLength(2);
+        args.forEach((node) => {
+            expect(node.parent).toBe(ast);
+        });
+    });
+});


### PR DESCRIPTION
Fixes a bug in which some parent references are discarded while converting from the `moc.js` AST format. 