### PR TITLE
Fix corner cases with AST `parent` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -24,6 +24,12 @@ export interface Node extends Partial<Source> {
     args?: AST[];
 }
 
+export function asNode(ast: AST | undefined): Node | undefined {
+    return ast && typeof ast === 'object' && !Array.isArray(ast)
+        ? ast
+        : undefined;
+}
+
 export function simplifyAST(ast: CompilerNode, parent?: Node | undefined): Node;
 export function simplifyAST(
     ast: CompilerAST[],

--- a/src/file.ts
+++ b/src/file.ts
@@ -67,7 +67,7 @@ export const file = (mo: Motoko, path: string) => {
             return mo.parseMotoko(result.read());
         },
         parseMotokoTyped() {
-            return mo.parseMotokoTyped([path]);
+            return mo.parseMotokoTyped(path);
         },
     };
     return result;

--- a/tests/ast.test.ts
+++ b/tests/ast.test.ts
@@ -23,7 +23,11 @@ describe('ast', () => {
         });
     });
 
-    test('parent property in actor file', async () => {
+    test('parent property in typed AST', async () => {
+        mo.loadPackage(require('../packages/latest/base.json'));
+        const file = mo.file('AST.mo');
+        file.write(actorSource);
+
         const check = (node: Node) => {
             for (const arg of node.args || []) {
                 const argNode = asNode(arg);
@@ -33,7 +37,7 @@ describe('ast', () => {
                 }
             }
         };
-        const node = asNode(mo.parseMotoko(actorSource));
+        const node = asNode(file.parseMotokoTyped().ast);
         expect(node).toBeTruthy();
         check(node!);
     });

--- a/tests/ast.test.ts
+++ b/tests/ast.test.ts
@@ -1,8 +1,18 @@
 import mo from '../src/versions/moc';
-import { Node } from '../src/ast';
+import { Node, asNode, AST } from '../src/ast';
+
+const actorSource = `
+import { print } "mo:base/Debug";
+
+actor Main {
+    public query func test() : async Nat {
+        123
+    }
+};
+`;
 
 describe('ast', () => {
-    test('parent property', async () => {
+    test('parent property in expression', async () => {
         const ast = mo.parseMotoko('let x = 0; x');
         const args = ast.args!.filter(
             (arg) => arg && typeof arg === 'object' && !Array.isArray(arg),
@@ -11,5 +21,20 @@ describe('ast', () => {
         args.forEach((node) => {
             expect(node.parent).toBe(ast);
         });
+    });
+
+    test('parent property in actor file', async () => {
+        const check = (node: Node) => {
+            for (const arg of node.args || []) {
+                const argNode = asNode(arg);
+                if (argNode) {
+                    expect(argNode.parent).toBe(node);
+                    check(argNode);
+                }
+            }
+        };
+        const node = asNode(mo.parseMotoko(actorSource));
+        expect(node).toBeTruthy();
+        check(node!);
     });
 });


### PR DESCRIPTION
Ensures that the hidden `parent` property is propagated as expected within both untyped and typed ASTs. 