### PR TITLE
Simplify return value from `file.parseMotokoTyped()`

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -67,7 +67,7 @@ export const file = (mo: Motoko, path: string) => {
             return mo.parseMotoko(result.read());
         },
         parseMotokoTyped() {
-            return mo.parseMotokoTyped([path]);
+            return mo.parseMotokoTyped(path);
         },
     };
     return result;


### PR DESCRIPTION
Adjusts `file.parseMotokoTyped()` to return a single `ParseMotokoTypedResult` instead of a singleton array. 