### PR TITLE
Add `doc-comment` code snippet

### DIFF
--- a/contrib/snippets.json
+++ b/contrib/snippets.json
@@ -420,6 +420,15 @@
             "Timer.cancelTimer(${1:id});"
         ]
     },
+    "Doc Comment": {
+        "prefix": [
+        "doc"
+        ],
+        "body": [
+            "",
+            "/// ${1:Description}"
+        ]
+    },
     "Array to Blob": {
         "prefix": [
             "array-2-blob"

--- a/contrib/snippets.json
+++ b/contrib/snippets.json
@@ -422,10 +422,9 @@
     },
     "Doc Comment": {
         "prefix": [
-        "doc"
+            "doc-comment"
         ],
         "body": [
-            "",
             "/// ${1:Description}"
         ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",


### PR DESCRIPTION
Includes a code snippet to clarify the syntax for doc comments ([original request](https://forum.dfinity.org/t/ask-how-should-we-improve-motoko/14573/55)).