### PR TITLE
Fall back to GitHub from CDN in package download logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.5.2",
+            "version": "3.5.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/package.ts
+++ b/src/package.ts
@@ -66,7 +66,6 @@ async function fetchPackageFiles(
     }
     const repoPart = info.repo.slice(prefix.length, -suffix.length);
 
-    // TODO: modify condition?
     const possiblyCDN = !(
         (info.branch &&
             info.branch.length % 2 === 0 &&
@@ -75,16 +74,21 @@ async function fetchPackageFiles(
         info.branch === 'main'
     );
     if (possiblyCDN) {
-        const result = await fetchFromService(
-            info,
-            'CDN',
-            `https://data.jsdelivr.com/v1/package/gh/${repoPart}@${info.branch}/flat`,
-            `https://cdn.jsdelivr.net/gh/${repoPart}@${info.branch}`,
-            'files',
-            'name',
-        );
-        if (result?.length) {
-            return result;
+        try {
+            const result = await fetchFromService(
+                info,
+                'CDN',
+                `https://data.jsdelivr.com/v1/package/gh/${repoPart}@${info.branch}/flat`,
+                `https://cdn.jsdelivr.net/gh/${repoPart}@${info.branch}`,
+                'files',
+                'name',
+            );
+            if (result?.length) {
+                return result;
+            }
+        }
+        catch(err) {
+            console.error('[CDN]', err);
         }
     }
     return await fetchFromService(


### PR DESCRIPTION
This change makes it possible to download packages from branches which are missing in JSDelivr but available on GitHub.