### PR TITLE
Fix type of `Diagnostic.severity`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.5.8",
+    "version": "3.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.5.8",
+    "version": "3.6.0",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export type Diagnostic = {
         start: { line: number; character: number };
         end: { line: number; character: number };
     };
-    severity: string;
+    severity: number;
     code: string;
     category: string;
     message: string;


### PR DESCRIPTION
The `Diagnostic` type definition was originally of type `string`. This PR changes this to `number`, which has the added benefit of making the type definition compatible with VS Code's `Diagnostic` type.