### PR TITLE
Fix character encoding from moc.js interpreter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.6.15",
+    "version": "3.6.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.6.15",
+            "version": "3.6.16",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.6.15",
+    "version": "3.6.16",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
     installPackages,
     validatePackage,
 } from './package';
+import { asciiToUtf8 } from './utils/asciiToUtf8';
 import { resolveLib, resolveMain } from './utils/resolveEntryPoint';
 
 export type Motoko = ReturnType<typeof wrapMotoko>;
@@ -164,7 +165,10 @@ export default function wrapMotoko(compiler: Compiler) {
             path: string,
             libPaths?: string[] | undefined,
         ): { stdout: string; stderr: string; result: Result } {
-            return invoke('run', false, [libPaths || [], path]);
+            const result = invoke('run', false, [libPaths || [], path]);
+            result.stdout = asciiToUtf8(result.stdout);
+            result.stderr = asciiToUtf8(result.stderr);
+            return result;
         },
         candid(path: string): string {
             return invoke('candid', true, [path]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,10 +165,10 @@ export default function wrapMotoko(compiler: Compiler) {
             path: string,
             libPaths?: string[] | undefined,
         ): { stdout: string; stderr: string; result: Result } {
-            const result = invoke('run', false, [libPaths || [], path]);
-            result.stdout = asciiToUtf8(result.stdout);
-            result.stderr = asciiToUtf8(result.stderr);
-            return result;
+            const run = invoke('run', false, [libPaths || [], path]);
+            run.stdout = asciiToUtf8(run.stdout);
+            run.stderr = asciiToUtf8(run.stderr);
+            return run;
         },
         candid(path: string): string {
             return invoke('candid', true, [path]);

--- a/src/utils/asciiToUtf8.ts
+++ b/src/utils/asciiToUtf8.ts
@@ -1,9 +1,10 @@
 const textDecoder = new TextDecoder();
 
 /// Convert an ASCII string from `js_of_ocaml` to a UTF-8 string.
-export const asciiToUtf8 = (text: string): string =>
-    textDecoder.decode(
+export const asciiToUtf8 = (text: string): string => {
+    return textDecoder.decode(
         Uint8Array.from({ length: text.length }).map((_, i) =>
             text.charCodeAt(i),
         ),
     );
+};

--- a/src/utils/asciiToUtf8.ts
+++ b/src/utils/asciiToUtf8.ts
@@ -1,0 +1,9 @@
+const textDecoder = new TextDecoder();
+
+/// Convert an ASCII string from `js_of_ocaml` to a UTF-8 string.
+export const asciiToUtf8 = (text: string): string =>
+    textDecoder.decode(
+        Uint8Array.from({ length: text.length }).map((_, i) =>
+            text.charCodeAt(i),
+        ),
+    );

--- a/tests/interpreter.test.ts
+++ b/tests/interpreter.test.ts
@@ -73,4 +73,13 @@ describe('run', () => {
             '`ys6dh-5cjiq-5dc` : actor {abc : shared () -> async Nat}\n',
         );
     });
+
+    test('output charset', () => {
+        const { stdout } = testMotoko(
+            `import {debugPrint} "mo:prim"; debugPrint("smażone");`,
+        );
+        expect(stdout).toStrictEqual(
+            'smażone\n() : ()\n',
+        );
+    });
 });


### PR DESCRIPTION
This PR converts the ASCII strings returned from `js_of_ocaml` to the expected UTF-8 character set. 