### PR TITLE
Rename `setMetadata()` to `setPublicMetadata()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ mo.validatePackage(package)
 mo.setAliases(directory, { alias: id, ... })
 
 // Set the public metadata (an array of strings) used by the compiler
-mo.setMetadata(strings)
+mo.setPublicMetadata(strings)
 
 // Set the maximum number of interpreter steps before cancelling a `run()` invocation
 mo.setRunStepLimit(limit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.8.4",
+    "version": "3.9.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.8.4",
+            "version": "3.9.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.8.4",
+    "version": "3.9.0",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export default function wrapMotoko(compiler: Compiler) {
             invoke('setCandidPath', false, [directory]);
             invoke('setActorAliases', false, [Object.entries(aliases)]);
         },
-        setMetadata(values: string) {
+        setPublicMetadata(values: string[]) {
             invoke('setPublicMetadata', false, [values]);
         },
         setRunStepLimit(limit: number) {


### PR DESCRIPTION
Renames `setMetadata()` and fixes the parameter type.