### PR TITLE
Release 3.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "3.14.0",
+            "version": "3.14.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixes a regression with Wasm compilation (see https://github.com/dfinity/node-motoko/pull/140).
