### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       version_changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: dispatch-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
             vscode-motoko
 
       - name: Trigger vscode-motoko (bump motoko npm in extension)
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ steps.dispatch-token.outputs.token }}
           repository: caffeinelabs/vscode-motoko

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -6,8 +6,8 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: npm ci
-      - uses: andresz1/size-limit-action@v1
+      - uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/update-moc.yml
+++ b/.github/workflows/update-moc.yml
@@ -32,10 +32,10 @@ jobs:
   update-moc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -94,13 +94,13 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
           private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: auto/moc-${{ steps.versions.outputs.moc_version }}


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 27d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `peter-evans/repository-dispatch@v3` -> `peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3`
  - Version: v3 | Latest: v4.0.1 | Release age: 146d
  - Commit: https://github.com/peter-evans/repository-dispatch/commit/ff45666b9427631e3450c54a1bcbee4d9ff4d7c0

- `andresz1/size-limit-action@v1` -> `andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1`
  - Version: v1.6.1 | Latest: v1.8.0 | Release age: 733d
  - Commit: https://github.com/andresz1/size-limit-action/commit/e7493a72a44b113341c0cf6186ab49c17c4b65c1

- `peter-evans/create-pull-request@v7` -> `peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11`
  - Version: v7.0.11 | Latest: v8.1.0 | Release age: 78d
  - Commit: https://github.com/peter-evans/create-pull-request/commit/22a9089034f40e5a961c8808d113e2c98fb63676


### Files modified

- `.github/workflows/publish.yml`
- `.github/workflows/size.yml`
- `.github/workflows/tests.yml`
- `.github/workflows/update-moc.yml`